### PR TITLE
IE8 support

### DIFF
--- a/src/insertCss.js
+++ b/src/insertCss.js
@@ -92,10 +92,11 @@ function insertCss(styles, options) {
     }
 
     if (create) {
+      let head = document.head || document.getElementsByTagName('head')[0];
       if (prepend) {
-        document.head.insertBefore(elem, document.head.childNodes[0]);
+        head.insertBefore(elem, document.head.childNodes[0]);
       } else {
-        document.head.appendChild(elem);
+        head.appendChild(elem);
       }
     }
   }


### PR DESCRIPTION
in IE 8, the call document.head returns null, hence added a check here would make this great plugin suitable for below IE9.
